### PR TITLE
Build to ghpages branch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/checkout@master
       with:
         repository: coopdigital/build-your-own-radar
-        token: ${{ secrets.blog_repo_access }}
+        token: ${{ secrets.repo_access }}
         path: _site
     - name: build site
       run: npm run test && npm run end_to_end_test && npm run build
@@ -34,5 +34,5 @@ jobs:
         git config --global user.name "Github Actions CI" && \
         git config --global user.email automagic@actions.com && \
         git commit -m "${GITHUB_RUN_NUMBER} auto-pushed to github" && \
-        git push https://${{ secrets.blog_repo_access }}@github.com/coopdigital/build-your-own-radar.git master:master
+        git push https://${{ secrets.repo_access }}@github.com/coopdigital/build-your-own-radar.git master:master
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,38 @@
+name: Build site
+
+on:
+  push:
+    branches: [ build_to_ghpages_branch ]
+  pull_request:
+    branches: [ build_to_ghpages_branch ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 2
+    - uses: actions/setup-node@v2-beta
+      with:
+        node-version: '10.15.3'
+    - name: pre build
+      run: npm ci
+    - name: get the current state of the site
+      uses: actions/checkout@master
+      with:
+        repository: coopdigital/build-your-own-radar
+        token: ${{ secrets.blog_repo_access }}
+        path: _site
+    - name: build site
+      run: npm run test && npm run end_to_end_test && npm run build
+    - name: deploy
+      run: |
+        git add -A && \
+        git config --global user.name "Github Actions CI" && \
+        git config --global user.email automagic@actions.com && \
+        git commit -m "${GITHUB_RUN_NUMBER} auto-pushed to github" && \
+        git push https://${{ secrets.blog_repo_access }}@github.com/coopdigital/build-your-own-radar.git master:master
+

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,6 +20,11 @@ jobs:
         node-version: '10.15.3'
     - name: pre build
       run: npm ci
+    - name: get the current state of the site
+      uses: actions/checkout@master
+      with:
+        repository: coopdigital/build-your-own-radar
+        token: ${{ secrets.repo_access }}
     - name: build site
       run: npm run test && npm run build
     - name: deploy

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,13 +18,13 @@ jobs:
     - uses: actions/setup-node@v2-beta
       with:
         node-version: '10.15.3'
-    - name: pre build
-      run: npm ci
     - name: get the current state of the site
       uses: actions/checkout@master
       with:
         repository: coopdigital/build-your-own-radar
         token: ${{ secrets.repo_access }}
+    - name: pre build
+      run: npm ci
     - name: build site
       run: npm run test && npm run build
     - name: deploy

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,5 +41,5 @@ jobs:
         git config --global user.name "Github Actions CI" && \
         git config --global user.email automagic@actions.com && \
         git commit -m "${GITHUB_RUN_NUMBER} auto-pushed to github" && \
-        git push https://${{ secrets.repo_access }}@github.com/coopdigital/build-your-own-radar.git master:master
+        git push https://${{ secrets.repo_access }}@github.com/coopdigital/build-your-own-radar.git ${{ env.BRANCH_NAME }}:gh-pages
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,9 +2,9 @@ name: Build site
 
 on:
   push:
-    branches: [ build_to_ghpages_branch ]
+    branches: [ master ]
   pull_request:
-    branches: [ build_to_ghpages_branch ]
+    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,11 +18,22 @@ jobs:
     - uses: actions/setup-node@v2-beta
       with:
         node-version: '10.15.3'
-    - name: get the current state of the site
-      uses: actions/checkout@master
-      with:
-        repository: coopdigital/build-your-own-radar
-        token: ${{ secrets.repo_access }}
+    # extract branch name
+    - name: Extract branch name
+      if: github.event_name != 'pull_request'
+      shell: bash
+      run: echo "::set-env name=BRANCH_NAME::$(echo ${GITHUB_REF#refs/heads/})"
+      id: extract_branch
+
+    # extract branch name on pull request
+    - name: Print branch name
+      if: github.event_name == 'pull_request'
+      run: echo "::set-env name=BRANCH_NAME::$(echo ${GITHUB_HEAD_REF})"
+
+    # print branch name
+    - name: Get branch name
+      run: echo 'The branch name is' $BRANCH_NAME
+
     - name: pre build
       run: npm ci
     - name: build site

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,7 @@ jobs:
         token: ${{ secrets.repo_access }}
         path: _site
     - name: build site
-      run: npm run test && npm run end_to_end_test && npm run build
+      run: npm run test && npm run build
     - name: deploy
       run: |
         git add -A && \

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,21 +18,18 @@ jobs:
     - uses: actions/setup-node@v2-beta
       with:
         node-version: '10.15.3'
-    # extract branch name
-    - name: Extract branch name
+    - name: Get branch name (merge)
       if: github.event_name != 'pull_request'
       shell: bash
-      run: echo "::set-env name=BRANCH_NAME::$(echo ${GITHUB_REF#refs/heads/})"
-      id: extract_branch
+      run: echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
 
-    # extract branch name on pull request
-    - name: Print branch name
+    - name: Get branch name (pull request)
       if: github.event_name == 'pull_request'
-      run: echo "::set-env name=BRANCH_NAME::$(echo ${GITHUB_HEAD_REF})"
+      shell: bash
+      run: echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF} | tr / -)" >> $GITHUB_ENV
 
-    # print branch name
-    - name: Get branch name
-      run: echo 'The branch name is' $BRANCH_NAME
+    - name: Debug
+      run: echo ${{ env.BRANCH_NAME }}
 
     - name: pre build
       run: npm ci

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,12 +20,6 @@ jobs:
         node-version: '10.15.3'
     - name: pre build
       run: npm ci
-    - name: get the current state of the site
-      uses: actions/checkout@master
-      with:
-        repository: coopdigital/build-your-own-radar
-        token: ${{ secrets.repo_access }}
-        path: _site
     - name: build site
       run: npm run test && npm run build
     - name: deploy

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 bower_components
 dist
+docs
 *.swa
 *.swp
 *.swo


### PR DESCRIPTION
adds a github action that when code is merged or pushed to master builds the site and commits to the gh-pages branch

this lets us serve gh pages without needing to have built artefacts (in trunk/commit) before pushing to github

If merged the settings for the repo need to be changed so that the gh-pages branch is used to serve gh-pages